### PR TITLE
Updated SharpZipLib dependency

### DIFF
--- a/nuspec/Cake.Compression.nuspec
+++ b/nuspec/Cake.Compression.nuspec
@@ -14,7 +14,7 @@
     <copyright>Copyright (c) 2016 Artur Kordowski</copyright>
     <tags>cake build compression bzip2 gzip tar zip</tags>
     <dependencies>
-      <dependency id="SharpZipLib" version="1.1.0" />
+      <dependency id="SharpZipLib" version="1.2.0" />
     </dependencies>
   </metadata>
 </package>

--- a/src/Cake.Compression.Tests/Cake.Compression.Tests.csproj
+++ b/src/Cake.Compression.Tests/Cake.Compression.Tests.csproj
@@ -4,11 +4,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Testing" Version="0.33.0" />
-    <PackageReference Include="NSubstitute" Version="4.0.0" />
-    <PackageReference Include="NUnit" Version="3.11.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+    <PackageReference Include="Cake.Testing" Version="0.34.1" />
+    <PackageReference Include="NSubstitute" Version="4.2.1" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Cake.Compression/Cake.Compression.csproj
+++ b/src/Cake.Compression/Cake.Compression.csproj
@@ -9,7 +9,7 @@
     <DocumentationFile>bin\Release\netstandard2.0\Cake.Compression.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Cake.Common" version="0.33.0" PrivateAssets="All" />
-    <PackageReference Include="SharpZipLib" version="1.1.0" />
+    <PackageReference Include="Cake.Common" version="0.34.1" PrivateAssets="All" />
+    <PackageReference Include="SharpZipLib" version="1.2.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The current version of the SharpZipLib nuget package updated to version 1.2.0 which caused many of my build scripts to fail since this Cake.Compression nuget package references the 1.1.0 version. I updated the SharpZipLib dependency reference to the newest 1.2.0 along with a few other minor references. I ran a full test to verify everything builds and runs properly. 